### PR TITLE
Separate out pages and bump a tag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NeuralOperators"
 uuid = "ea5c82af-86e5-48da-8ee1-382d6ad7af4b"
 authors = ["JingYu Ning <foldfelis@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,8 @@ bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"), sorting=:nyt)
 
 DocMeta.setdocmeta!(NeuralOperators, :DocTestSetup, :(using NeuralOperators); recursive=true)
 
+include("pages.jl")
+
 makedocs(
     bib,
     modules=[NeuralOperators],
@@ -17,12 +19,7 @@ makedocs(
         canonical="http://neuraloperators.sciml.ai",
         assets=String[],
     ),
-    pages=[
-        "Home" => "index.md",
-        "Introduction" => "introduction.md",
-        "APIs" => "apis.md",
-        "References" => "references.md",
-    ],
+    pages=pages,
 )
 
 deploydocs(;

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,0 +1,8 @@
+# Put in a separate page so it can be used by SciMLDocs.jl
+
+pages = [
+        "Home" => "index.md",
+        "Introduction" => "introduction.md",
+        "APIs" => "apis.md",
+        "References" => "references.md",
+    ]


### PR DESCRIPTION
We're building a SciML global documentation (https://docs.sciml.ai/dev/, https://github.com/SciML/SciMLDocs). All it should need is the `pages` definition in a separate file.